### PR TITLE
Fix index out of range in SetText

### DIFF
--- a/text.go
+++ b/text.go
@@ -1,5 +1,9 @@
 package termloop
 
+import (
+	"sync"
+)
+
 // Text represents a string that can be drawn to the screen.
 type Text struct {
 	x      int
@@ -8,6 +12,7 @@ type Text struct {
 	bg     Attr
 	text   []rune
 	canvas []Cell
+	mu     sync.Mutex
 }
 
 // NewText creates a new Text, at position (x, y). It sets the Text's
@@ -34,6 +39,9 @@ func (t *Text) Tick(ev Event) {}
 
 // Draw draws the Text to the Screen s.
 func (t *Text) Draw(s *Screen) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	w, _ := t.Size()
 	for i := 0; i < w; i++ {
 		s.RenderCell(t.x+i, t.y, &t.canvas[i])
@@ -63,6 +71,9 @@ func (t *Text) Text() string {
 
 // SetText sets the text of the Text to be text.
 func (t *Text) SetText(text string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	t.text = []rune(text)
 	c := make([]Cell, len(t.text))
 	for i := range c {


### PR DESCRIPTION
Fixes out of bounds errors thrown by SetText. Minimal code example (thanks Tomasz Potęga) this PR intends to fix:

```go
package main

import (
    "context"
    "github.com/grupawp/termloop"
)

func main() {
    game := termloop.NewGame()
    txt := termloop.NewText(0, 0, "jeden", termloop.ColorWhite, termloop.ColorBlack)
    go func() {
        for {
            txt.SetText("dwa")
            txt.SetText("trzy")
        }
    }()
    game.Screen().AddEntity(txt)
    game.Start(context.Background())
}
```

throws:
```
panic: runtime error: index out of range [3] with length 3

goroutine 1 [running]:
github.com/grupawp/termloop.(*Text).Draw(0x43da51?, 0xc00005dc80?)
	/home/Grelo4ka/go/pkg/mod/github.com/grupawp/termloop@v0.0.0-20230516071741-9af5ae3e8663/text.go:39 +0xf7
github.com/grupawp/termloop.(*Screen).Draw(0xc000130000)
	/home/Grelo4ka/go/pkg/mod/github.com/grupawp/termloop@v0.0.0-20230516071741-9af5ae3e8663/screen.go:54 +0x144
github.com/grupawp/termloop.(*Game).Start(0xc00005df40, {0x52ee80, 0xc0000180a8})
	/home/Grelo4ka/go/pkg/mod/github.com/grupawp/termloop@v0.0.0-20230516071741-9af5ae3e8663/game.go:120 +0x15a
main.main()
	/home/Grelo4ka/bug-fix/main.go:18 +0x413
exit status 2
```